### PR TITLE
Refactor content manager paths

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ import markdown
 import os
 import re
 import yaml
-import glob
+from pathlib import Path
 import bleach
 import random
 import httpx
@@ -287,20 +287,20 @@ class ContentManager:
     @staticmethod
     def get_content(content_type: str, limit=None):
         """Get content of a specific type with consistent format"""
-        files = glob.glob(f"{CONTENT_DIR}/{content_type}/*.md")
+        files = list(Path(CONTENT_DIR, content_type).glob("*.md"))
         files.sort(key=ContentManager._get_date_from_filename, reverse=True)
 
         content = []
         validation_errors = {}
         
         for file in files:
-            name = os.path.splitext(os.path.basename(file))[0]
-            file_content = ContentManager.render_markdown(file)
+            name = file.stem
+            file_content = ContentManager.render_markdown(str(file))
             metadata = file_content["metadata"]
             errors = file_content.get("errors", [])
 
             if errors:
-                validation_errors[file] = errors
+                validation_errors[str(file)] = errors
                 # Skip invalid content in production, include with errors in development
                 if os.getenv("ENVIRONMENT") == "production":
                     continue
@@ -347,18 +347,18 @@ class ContentManager:
         }
 
     @staticmethod
-    def _get_date_from_filename(filename: str) -> str:
-        match = re.search(r'(\d{4}-\d{2}-\d{2})', os.path.basename(filename))
+    def _get_date_from_filename(filename: str | Path) -> str:
+        match = re.search(r'(\d{4}-\d{2}-\d{2})', Path(filename).name)
         return match.group(1) if match else '0000-00-00'
 
     @staticmethod
     def get_random_quote():
-        quote_files = glob.glob(f"{CONTENT_DIR}/notes/*quoting*.md")
+        quote_files = list(Path(CONTENT_DIR, "notes").glob("*quoting*.md"))
         if not quote_files:
             return None
 
         random_quote_file = random.choice(quote_files)
-        quote_content = ContentManager.render_markdown(random_quote_file)
+        quote_content = ContentManager.render_markdown(str(random_quote_file))
 
         # Extract quote safely
         soup = BeautifulSoup(quote_content["html"], 'html.parser')
@@ -373,15 +373,15 @@ class ContentManager:
     @staticmethod
     def get_bookmarks(limit: Optional[int] = 10) -> List[dict]:
         """Get bookmarks with pagination"""
-        files = glob.glob(f"{CONTENT_DIR}/bookmarks/*.md")
+        files = list(Path(CONTENT_DIR, "bookmarks").glob("*.md"))
         files.sort(key=ContentManager._get_date_from_filename, reverse=True)
         bookmarks = []
         files_to_process = files if limit is None else sorted(
             files, reverse=True)[:limit]
 
         for file in files_to_process:
-            name = os.path.splitext(os.path.basename(file))[0]
-            file_content = ContentManager.render_markdown(file)
+            name = file.stem
+            file_content = ContentManager.render_markdown(str(file))
             metadata = file_content["metadata"]
 
             # Convert the metadata to a Bookmark model for validation
@@ -417,10 +417,10 @@ class ContentManager:
             content_types = ["notes", "how_to", "til"]
 
         for content_type in content_types:
-            files = glob.glob(f"{CONTENT_DIR}/{content_type}/*.md")
+            files = Path(CONTENT_DIR, content_type).glob("*.md")
             for file in files:
-                name = os.path.splitext(os.path.basename(file))[0]
-                file_content = ContentManager.render_markdown(file)
+                name = file.stem
+                file_content = ContentManager.render_markdown(str(file))
                 metadata = file_content["metadata"]
 
                 if "tags" in metadata and tag in metadata["tags"]:
@@ -546,7 +546,7 @@ class ContentManager:
     @staticmethod
     def get_til_posts(page: int = 1, per_page: int = 30) -> dict:
         """Get TiL posts with pagination"""
-        files = glob.glob(f"{CONTENT_DIR}/til/*.md")
+        files = list(Path(CONTENT_DIR, "til").glob("*.md"))
         files.sort(key=ContentManager._get_date_from_filename, reverse=True)
 
         # Calculate pagination
@@ -558,8 +558,8 @@ class ContentManager:
         til_tags = {}
 
         for file in page_files:
-            name = os.path.splitext(os.path.basename(file))[0]
-            file_content = ContentManager.render_markdown(file)
+            name = file.stem
+            file_content = ContentManager.render_markdown(str(file))
             metadata = file_content["metadata"]
 
             # Get first paragraph for excerpt
@@ -598,12 +598,12 @@ class ContentManager:
     @staticmethod
     def get_til_posts_by_tag(tag: str) -> List[dict]:
         """Get TiL posts filtered by tag"""
-        files = glob.glob(f"{CONTENT_DIR}/til/*.md")
+        files = list(Path(CONTENT_DIR, "til").glob("*.md"))
         tils = []
 
         for file in files:
-            name = os.path.splitext(os.path.basename(file))[0]
-            file_content = ContentManager.render_markdown(file)
+            name = file.stem
+            file_content = ContentManager.render_markdown(str(file))
             metadata = file_content["metadata"]
 
             if tag in metadata.get("tags", []):

--- a/app/main.py
+++ b/app/main.py
@@ -417,7 +417,7 @@ class ContentManager:
             content_types = ["notes", "how_to", "til"]
 
         for content_type in content_types:
-            files = Path(CONTENT_DIR, content_type).glob("*.md")
+            files = list(Path(CONTENT_DIR, content_type).glob("*.md"))
             for file in files:
                 name = file.stem
                 file_content = ContentManager.render_markdown(str(file))


### PR DESCRIPTION
### **User description**
## Summary
- migrate `ContentManager` to `pathlib.Path`
- use `Path.glob` for all markdown lookups

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored content file operations to use `pathlib.Path`

- Replaced `glob.glob` and `os.path` with `Path.glob` and `Path` methods

- Improved code readability and consistency in file handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Refactor file and path handling to use pathlib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main.py

<li>Replaced all uses of <code>glob.glob</code> with <code>Path.glob</code> for markdown file <br>lookups.<br> <li> Updated file name and path manipulations to use <code>Path</code> methods (<code>stem</code>, <br><code>name</code>).<br> <li> Adjusted helper methods to accept and handle <code>Path</code> objects.<br> <li> Removed unnecessary imports (<code>glob</code>, some <code>os.path</code> usages).


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/digital-garden/pull/7/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>