### PR TITLE
Add single-thread cache note

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,10 @@ Type checking:
 ```bash
 mypy .
 ```
+
+## Usage Notes
+
+The `timed_lru_cache` decorator in `app/main.py` keeps its data in process
+memory and does not implement any locking. It is designed for single-threaded
+execution. For deployments with multiple workers or threads, prefer an external
+cache instead of this helper.

--- a/app/main.py
+++ b/app/main.py
@@ -99,8 +99,12 @@ else:
         print(f"Warning: Failed to configure Logfire: {e}. Running without logging in development mode.")
 
 class timed_lru_cache:
-    """
-    Decorator that adds time-based expiration to LRU cache
+    """Decorator that adds time-based expiration to an in-memory LRU cache.
+
+    The cache uses regular Python dictionaries and is **not** thread safe.
+    It is intended for single-threaded use such as development servers or
+    scripts. Use an external cache if you need multi-process or multi-threaded
+    safety.
     """
 
     def __init__(self, maxsize: int = 128, ttl_seconds: int = 3600):


### PR DESCRIPTION
### **User description**
## Summary
- clarify that `timed_lru_cache` is for single-threaded use
- document the cache usage note in README

## Testing
- `pytest -q` *(fails: command not found)*


___

### **PR Type**
Documentation


___

### **Description**
- Clarify single-threaded usage of `timed_lru_cache` in code docstring

- Add usage note about cache thread safety to README


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Clarify thread safety and usage of `timed_lru_cache` in docstring</code></dd></summary>
<hr>

app/main.py

<li>Expanded <code>timed_lru_cache</code> docstring to clarify lack of thread safety<br> <li> Stated intended use for single-threaded scenarios in docstring


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/digital-garden/pull/8/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add usage notes for `timed_lru_cache` thread safety in README</code></dd></summary>
<hr>

README.md

<li>Added section on <code>timed_lru_cache</code> usage and thread safety<br> <li> Warned against using in multi-threaded or multi-worker deployments


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/digital-garden/pull/8/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>