### PR TITLE
Fix duplicate route decorator

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -986,7 +986,6 @@ async def read_now(request: Request):
 
 
 @app.get("/tags/{tag}", response_class=HTMLResponse)
-@app.get("/tags/{tag}", response_class=HTMLResponse)
 async def read_tag(request: Request, tag: str):
     # Get content type from query parameter, default to all
     content_type = request.query_params.get("type")


### PR DESCRIPTION
### **User description**
## Summary
- remove redundant route decorator for `read_tag` endpoint

## Testing
- `pytest -q` *(fails: command not found)*
- `pip install pytest pytest-asyncio -q` *(fails: could not find a version that satisfies the requirement)*


___

### **PR Type**
Bug fix


___

### **Description**
- Removed duplicate route decorator for `read_tag` endpoint

- Prevents potential routing conflicts and redundancy


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Remove duplicate route decorator for read_tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main.py

<li>Deleted redundant <code>@app.get("/tags/{tag}", ...)</code> decorator above <br><code>read_tag</code><br> <li> Ensures only one route definition for the endpoint


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/digital-garden/pull/9/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>